### PR TITLE
Fix makefile issue

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC=g++
 CCFLAGS=-O2 -g
-LDFLAGS=-lX11 -lXext
+LDFLAGS=-lX11 -lXext -lrt
 SOURCES=main.cpp x.cpp options.cpp
 OBJECTS=$(SOURCES:.cpp=.o)
 EXECUTABLE=slop


### PR DESCRIPTION
The following commit fixes an issue which is present on certain systems when compiling, where librt isn't automatically linked in. If it is automatically linked, this doesn't do anything.
