### PR TITLE
slop is now available in Void Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ While slop not only looks nicer, it's impossible for it to end up in screenshots
 ### Install using your Package Manager (Preferred)
 
 * [Arch Linux: community/slop](https://www.archlinux.org/packages/community/x86_64/slop/)
+* [Void Linux: slop](https://github.com/voidlinux/void-packages/blob/24ac22af44018e2598047e5ef7fd3522efa79db5/srcpkgs/slop/template)
 * Please make a package for slop on your favorite system, and make a pull request to add it to this list.
 
 


### PR DESCRIPTION
Not sure whether to link to http://repo.voidlinux.eu/current/ or the template that I constructed, which was processed by the buildbot after the merge.
