### PR TITLE
Ignore BadValue errors from XQueryKeymap

### DIFF
--- a/src/x.cpp
+++ b/src/x.cpp
@@ -28,6 +28,12 @@ int slop::XEngineErrorHandler( Display* dpy, XErrorEvent* event ) {
         fprintf( stderr, "_X Error \"BadAccess\" for XGrabKeyboard ignored...\n" );
         return EXIT_SUCCESS;
     }
+    // Ignore XQueryKeymap BadValue errors, we can work without it.
+    // 128 = XShape request code, not sure why XQueryKeymap generates this?
+    if ( event->request_code == 128 && event->error_code == BadValue ) {
+        fprintf( stderr, "_X Error \"BadValue\" for XQueryKeymap ignored...\n" );
+        return EXIT_SUCCESS;
+    }
     // Everything else should be fatal as I don't like undefined behavior.
     char buffer[1024];
     XGetErrorText( dpy, event->error_code, buffer, 1024 );


### PR DESCRIPTION
Not sure why I'm getting an error related to the XShape extension from `XQueryKeymap` on my VNC server (only occurs after `slop` has started drawing stuff).  This fixes #15, see related discussion there.

---

Mostly for my own future reference, [this table](http://www.rahul.net/kenton/xproto/xrequests.html) lists `QueryKeymap = 44`, and from [this page](http://www.x.org/wiki/Development/Documentation/Protocol/OpCodes/):

```
$ DISPLAY=:1 xdpyinfo -queryExt | grep 'opcode: 128'
    SHAPE  (opcode: 128, base event: 64)
```
