### PR TITLE
Add Gentoo package in 'fkmclane' overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ While slop not only looks nicer, it's impossible for it to end up in screenshots
 * [FreeBSD: x11/slop](http://www.freshports.org/x11/slop/)
 * [OpenBSD: graphics/slop](http://openports.se/graphics/slop)
 * [CRUX: 6c37/slop](https://github.com/6c37/crux-ports/tree/master/slop)
+* [Gentoo: x11-misc/slop::fkmclane](https://github.com/fkmclane/overlay/tree/master/x11-misc/slop)
 * Please make a package for slop on your favorite system, and make a pull request to add it to this list.
 
 


### PR DESCRIPTION
I created a package for slop currently in the 'fkmclane' overlay that can be added through layman (`# layman -a fkmclane`).