### PR TITLE
These things are not needed if you're not compiling with OpenGL.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -253,7 +253,9 @@ int app( int argc, char** argv ) {
     bool decorations = !options.nodecorations_flag;
     bool themeon = (bool)options.theme_given;
     std::string theme = options.theme_arg;
+#ifdef OPENGL_ENABLED
     bool shadergiven = (bool)options.shader_given;
+#endif
     std::string shader = options.shader_arg;
     struct timespec start, time;
     int xoffset = 0;
@@ -274,12 +276,14 @@ int app( int argc, char** argv ) {
     }
     std::string format = options.format_arg;
     bool magenabled = options.magnify_flag;
+#ifdef OPENGL_ENABLED
     float magstrength = options.magstrength_arg;
     if ( options.magpixels_arg < 0 ) {
         fprintf( stderr, "Error: --magpixels < 0, it's an unsigned integer you twat. Stop trying to underflow me!\n" );
         return EXIT_FAILURE;
     }
     unsigned int magpixels = (unsigned int)options.magpixels_arg;
+#endif
     cmdline_parser_free( &options );
 #ifndef OPENGL_ENABLED
     if ( opengl || themeon || magenabled ) {

--- a/src/shader.hpp
+++ b/src/shader.hpp
@@ -6,9 +6,11 @@
 #include <string>
 #include <cstdio>
 #include <vector>
+#ifdef OPENGL_ENABLED
 #include <glm/glm.hpp>
 #include <glm/gtc/type_ptr.hpp>
 #include <GL/glew.h>
+#endif
 #include <string>
 #include <fstream>
 #include <streambuf>
@@ -25,9 +27,11 @@ public:
     void            unbind();
     void            setParameter( std::string name, int foo );
     void            setParameter( std::string name, float foo );
+#ifdef OPENGL_ENABLED
     void            setParameter( std::string name, glm::mat4 foo );
     void            setParameter( std::string name, glm::vec4 foo );
     void            setParameter( std::string name, glm::vec2 foo );
+#endif
     void            setAttribute( std::string name, unsigned int buffer, unsigned int stepsize );
     int             m_type;
 private:


### PR DESCRIPTION
As it says on the tin.
Also has the added benefit of reducing dependencies for those not compiling in OpenGL support.
Warning-free build on OpenBSD with this, resulting slop works fine.