### PR TITLE
Specify std=c++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ add_definitions(-DSLOP_VERSION="v5.3.35")
 set(EXECUTABLE_NAME "slop")
 set(LIBRARY_NAME "slopy")
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 add_library(${LIBRARY_NAME} SHARED  src/mouse.cpp
                                     src/keyboard.cpp
                                     src/x.cpp


### PR DESCRIPTION
This prevents an error on my machine:

> This file requires compiler and library support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.

Full log:

```
$ make                                                           [442/442]
[  6%] Building CXX object CMakeFiles/slopy.dir/src/mouse.cpp.o
In file included from /usr/include/c++/4.9/chrono:35:0,
                 from /home/james/code/slop/src/mouse.cpp:1:
/usr/include/c++/4.9/bits/c++0x_warning.h:32:2: error: #error This file requires compiler and librar
y support for the ISO C++ 2011 standard. This support is currently experimental, and must be enabled
 with the -std=c++11 or -std=gnu++11 compiler options.
 #error This file requires compiler and library support for the \
  ^
/home/james/code/slop/src/mouse.cpp: In constructor ‘slop::Mouse::Mouse(slop::X11*, int, Window)’:
/home/james/code/slop/src/mouse.cpp:54:14: error: ‘std::this_thread’ has not been declared
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
              ^
/home/james/code/slop/src/mouse.cpp:54:42: error: ‘std::chrono’ has not been declared
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
                                          ^
CMakeFiles/slopy.dir/build.make:54: recipe for target 'CMakeFiles/slopy.dir/src/mouse.cpp.o' failed
make[2]: *** [CMakeFiles/slopy.dir/src/mouse.cpp.o] Error 1
CMakeFiles/Makefile2:95: recipe for target 'CMakeFiles/slopy.dir/all' failed
make[1]: *** [CMakeFiles/slopy.dir/all] Error 2
```