### PR TITLE
More realistic examples that actually exit when slop is cancelled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,16 @@ slop (Select Operation) is an application that queries for a selection from the 
 slop can be used to create a video recording script in only two lines of code.
 ```bash
 #!/bin/bash
-read -r X Y W H G ID < <(slop -f "%x %y %w %h %g %i")
+slop=$(slop -f "%x %y %w %h %g %i") || exit 1
+read -r X Y W H G ID < <(echo $slop)
 ffmpeg -f x11grab -s "$W"x"$H" -i :0.0+$X,$Y -f alsa -i pulse ~/myfile.webm
 ```
 
 You can also take images using imagemagick like so:
 ```bash
 #!/bin/bash
-read -r G < <(slop -f "%g")
+slop=$(slop -f "%g") || exit 1
+read -r G < <(echo $slop)
 import -window root -crop $G ~/myimage.png
 ```
 If you don't like ImageMagick's import: Check out [maim](https://github.com/naelstrof/maim) for a better screenshot utility.


### PR DESCRIPTION
I'm writing a little script to use slop, and I want my script to exit when someone cancels slop (for example, by pressing the escape key). The examples in the README don't seem to handle that case, because they run `slop` on one line via a `read -r ... < <(...)` expression, which means we cannot check slops exit code.

I changed the readme to split this into 2 lines so we can exit if slop was cancelled. I'm not sure if this is the cleanest way of achieving what I want, though. I'd love to hear if there's a better way of accomplishing my goal here.

Thanks for slop, it's a great tool!