### PR TITLE
Add move feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ slop (Select Operation) is an application that queries for a selection from the 
     * Set the color of the selection rectangles to match your theme! (Even supports transparency!)
     * Remove window decorations from selections.
 * Supports custom programmable shaders.
+* Move started selection by holding down the space bar.
 
 ## Practical Applications
 slop can be used to create a video recording script in only three lines of code.

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -35,6 +35,9 @@ void slop::Keyboard::update() {
     keys[ keycode / 8 ] = keys[ keycode / 8 ] & ~( 1 << ( keycode % 8 ) );
     keycode = XKeysymToKeycode( x11->display, XK_Down );
     keys[ keycode / 8 ] = keys[ keycode / 8 ] & ~( 1 << ( keycode % 8 ) );
+    // Also deleting Space for move operation
+    keycode = XKeysymToKeycode( x11->display, XK_space );
+    keys[ keycode / 8 ] = keys[ keycode / 8 ] & ~( 1 << ( keycode % 8 ) );
     keyDown = false;
     for ( int i=0;i<32;i++ ) {
         if ( deltaState[i] == keys[i] ) {

--- a/src/keyboard.hpp
+++ b/src/keyboard.hpp
@@ -22,6 +22,7 @@
 #define N_KEYBOARD_H_
 
 #define XK_MISCELLANY
+#define XK_LATIN1 // for XK_space
 #include <X11/keysymdef.h>
 
 #include "x.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -217,6 +217,7 @@ void printHelp() {
     std::cout << "Tips\n";
     std::cout << "    * If you don't like a selection: you can cancel it by right-clicking\n";
     std::cout << "regardless of which options are enabled or disabled for slop.\n";
+    std::cout << "    * You can move the selection by holding down the space bar!\n";
     std::cout << "    * If slop doesn't seem to select a window accurately, the problem could be\n";
     std::cout << "because of decorations getting in the way. Try enabling the --nodecorations\n";
     std::cout << "flag.\n";

--- a/src/slopstates.cpp
+++ b/src/slopstates.cpp
@@ -223,7 +223,7 @@ void slop::SlopStartMove::onEnter( SlopMemory& memory ) {
     //compensation comp = determineCompensation();
     //setPoints( memory, comp );
 
-    mouse->setCursor( XC_crosshair );
+    mouse->setCursor( XC_fleur );
 }
 void slop::SlopStartMove::update( SlopMemory& memory, double dt ) {
     // Unclear why it has to be - and not +

--- a/src/slopstates.cpp
+++ b/src/slopstates.cpp
@@ -91,25 +91,35 @@ void slop::SlopStartDrag::onEnter( SlopMemory& memory ) {
 }
 
 void slop::SlopStartDrag::update( SlopMemory& memory, double dt ) {
-    char a = startPoint.y > mouse->getMousePos().y;
-    char b = startPoint.x > mouse->getMousePos().x;
-    char c = (a << 1) | b;
+    
+    //these are true when on the edges of the screen
     int xm = (mouse->getMousePos().x == 0 || mouse->getMousePos().x == WidthOfScreen(x11->screen)-1);
     int ym = (mouse->getMousePos().y == 0 || mouse->getMousePos().y == HeightOfScreen(x11->screen)-1);
-    switch ( c ) {
-        case 0: mouse->setCursor( XC_lr_angle );
-                memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
-                break;
-        case 1: mouse->setCursor( XC_ll_angle );
-                memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
-                break;
-        case 2: mouse->setCursor( XC_ur_angle );
-                memory.rectangle->setPoints(startPoint+glm::vec2(0,1*ym), mouse->getMousePos()+glm::vec2(1*xm,0));
-                break;
-        case 3: mouse->setCursor( XC_ul_angle );
-                memory.rectangle->setPoints(startPoint+glm::vec2(1*xm,1*ym), mouse->getMousePos()+glm::vec2(0,0));
-                break;
+    
+    // set cursor and compensate edges somehow
+    bool curserAbove = startPoint.y > mouse->getMousePos().y;
+    bool cursorLeft = startPoint.x > mouse->getMousePos().x;
+
+    if ( curserAbove ) {
+        if ( cursorLeft ) {
+            mouse->setCursor( XC_ul_angle );
+            memory.rectangle->setPoints(startPoint+glm::vec2(1*xm,1*ym), mouse->getMousePos()+glm::vec2(0,0));        }
+        else {
+            mouse->setCursor( XC_ur_angle );
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,1*ym), mouse->getMousePos()+glm::vec2(1*xm,0));
+        }
     }
+    else {
+        if ( cursorLeft ) {
+            mouse->setCursor( XC_ll_angle );
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
+        }
+        else {
+            mouse->setCursor( XC_lr_angle );
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
+       }
+    }
+
     if ( !mouse->getButton( 1 ) ) {
         memory.setState( (SlopState*)new SlopEndDrag() );
     }

--- a/src/slopstates.cpp
+++ b/src/slopstates.cpp
@@ -91,38 +91,19 @@ void slop::SlopStartDrag::onEnter( SlopMemory& memory ) {
 }
 
 void slop::SlopStartDrag::update( SlopMemory& memory, double dt ) {
-    
-    //these are true when on the edges of the screen
-    int xm = (mouse->getMousePos().x == 0 || mouse->getMousePos().x == WidthOfScreen(x11->screen)-1);
-    int ym = (mouse->getMousePos().y == 0 || mouse->getMousePos().y == HeightOfScreen(x11->screen)-1);
-    
-    // set cursor and compensate edges somehow
-    bool curserAbove = startPoint.y > mouse->getMousePos().y;
-    bool cursorLeft = startPoint.x > mouse->getMousePos().x;
 
-    if ( curserAbove ) {
-        if ( cursorLeft ) {
-            mouse->setCursor( XC_ul_angle );
-            memory.rectangle->setPoints(startPoint+glm::vec2(1*xm,1*ym), mouse->getMousePos()+glm::vec2(0,0));        }
-        else {
-            mouse->setCursor( XC_ur_angle );
-            memory.rectangle->setPoints(startPoint+glm::vec2(0,1*ym), mouse->getMousePos()+glm::vec2(1*xm,0));
-        }
-    }
-    else {
-        if ( cursorLeft ) {
-            mouse->setCursor( XC_ll_angle );
-            memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
-        }
-        else {
-            mouse->setCursor( XC_lr_angle );
-            memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
-       }
-    }
+    setCursorAndPoints( memory );
 
     if ( !mouse->getButton( 1 ) ) {
         memory.setState( (SlopState*)new SlopEndDrag() );
+        return;
     }
+
+    if ( keyboard->getKey(XK_space) ) {
+        memory.setState( (SlopState*)new SlopStartMove( startPoint, mouse->getMousePos() ) );
+        return;
+    }
+
     if ( keyboard ) {
         int arrows[2];
         arrows[0] = keyboard->getKey(XK_Down)-keyboard->getKey(XK_Up);
@@ -150,3 +131,109 @@ void slop::SlopStartDrag::draw( SlopMemory& memory, glm::mat4 matrix ) {
 void slop::SlopEndDrag::onEnter( SlopMemory& memory ) {
     memory.running = false;
 }
+
+void slop::SlopStartDrag::setCursorAndPoints( SlopMemory& memory ) {
+    
+    //these are true when on the edges of the screen
+    int xm = (mouse->getMousePos().x == 0 || mouse->getMousePos().x == WidthOfScreen(x11->screen)-1);
+    int ym = (mouse->getMousePos().y == 0 || mouse->getMousePos().y == HeightOfScreen(x11->screen)-1);
+    
+    // set angle cursor and compensate edges somehow
+    bool cursorAbove = startPoint.y > mouse->getMousePos().y;
+    bool cursorLeft = startPoint.x > mouse->getMousePos().x;
+
+    if ( cursorAbove ) {
+        if ( cursorLeft ) {
+            mouse->setCursor( XC_ul_angle );
+            memory.rectangle->setPoints(startPoint+glm::vec2(1*xm,1*ym), mouse->getMousePos()+glm::vec2(0,0));        }
+        else {
+            mouse->setCursor( XC_ur_angle );
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,1*ym), mouse->getMousePos()+glm::vec2(1*xm,0));
+        }
+    }
+    else {
+        if ( cursorLeft ) {
+            mouse->setCursor( XC_ll_angle );
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
+        }
+        else {
+            mouse->setCursor( XC_lr_angle );
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
+       }
+    }
+}
+
+slop::SlopStartMove::SlopStartMove( glm::vec2 oldPoint, glm::vec2 newPoint ) {
+    // oldPoint is where drag was started and newPoint where move was
+    startPoint = oldPoint;
+    // This vector is the diagonal of the rectangle
+    // it will be used to move the startPoint along with mousePos
+    diagonal = newPoint - oldPoint;
+}
+
+void slop::SlopStartMove::onEnter( SlopMemory& memory ) {
+
+    memory.rectangle->setPoints( startPoint, mouse->getMousePos() );
+}
+
+void slop::SlopStartMove::update( SlopMemory& memory, double dt ) {
+
+    // Unclear why it has to be - and not +
+    startPoint = mouse->getMousePos() - diagonal;
+
+    setCursorAndPoints( memory );
+
+    // space or mouse1 released, return to drag
+    // if mouse1 is released then drag will end also
+    if ( !keyboard->getKey(XK_space) or !mouse->getButton( 1) ) {
+        memory.setState( (SlopState*) new SlopStartDrag(startPoint) );
+ //       memory.setState( (SlopState*)new SlopEndDrag() );
+    }
+
+}
+
+void slop::SlopStartMove::draw( SlopMemory& memory, glm::mat4 matrix ) {
+    memory.rectangle->draw( matrix );
+}
+
+
+void slop::SlopStartMove::setCursorAndPoints( SlopMemory& memory ) {
+    
+    // set cursor
+    mouse->setCursor( XC_cross );
+
+    // these are true when on the edges of the screen
+    int xm = (mouse->getMousePos().x == 0 || mouse->getMousePos().x == WidthOfScreen(x11->screen)-1);
+    int ym = (mouse->getMousePos().y == 0 || mouse->getMousePos().y == HeightOfScreen(x11->screen)-1);
+    
+    // compensate edges somehow
+    bool cursorAbove = startPoint.y > mouse->getMousePos().y;
+    bool cursorLeft = startPoint.x > mouse->getMousePos().x;
+
+    if ( cursorAbove ) {
+        if ( cursorLeft ) {
+            memory.rectangle->setPoints(startPoint+glm::vec2(1*xm,1*ym), mouse->getMousePos()+glm::vec2(0,0));        }
+        else {
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,1*ym), mouse->getMousePos()+glm::vec2(1*xm,0));
+        }
+    }
+    else {
+        if ( cursorLeft ) {
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
+        }
+        else {
+            memory.rectangle->setPoints(startPoint+glm::vec2(0,0), mouse->getMousePos()+glm::vec2(1*xm,1*ym));
+       }
+    }
+
+}
+
+/*
+slop::SlopResumeDrag::SlopResumeDrag( glm::vec2 point ) {
+    startPoint = point;
+}
+
+slop::SlopResumeDrag::onEnter( SlopMemory& memory ){
+}
+
+*/

--- a/src/slopstates.hpp
+++ b/src/slopstates.hpp
@@ -21,6 +21,8 @@
 #ifndef N_SLOPSTATES_H_
 #define N_SLOPSTATES_H_
 
+#include <array>
+
 #include "mouse.hpp"
 #include "keyboard.hpp"
 #include "slop.hpp"
@@ -33,6 +35,14 @@ class SlopMemory;
 class SlopOptions;
 
 class SlopState {
+protected:
+    glm::vec2 startPoint;
+    struct compensation {
+        glm::vec2 Start;
+        glm::vec2 Mouse;
+    };
+    virtual compensation determineCompensation();
+    virtual void setPoints( SlopMemory& memory, compensation comp );
 public:
     virtual ~SlopState();
     virtual void onEnter( SlopMemory& memory );
@@ -41,27 +51,24 @@ public:
     virtual void draw( SlopMemory& memory, glm::mat4 matrix );
 };
 
-class SlopStart : protected SlopState {
+class SlopStart : SlopState {
 private:
     bool setStartPos;
-    glm::vec2 startPos;
 public:
     virtual void onEnter( SlopMemory& memory );
     virtual void update( SlopMemory& memory, double dt );
     virtual void draw( SlopMemory& memory, glm::mat4 matrix );
 };
 
-class SlopStartDrag : protected SlopState {
-protected:
-    glm::vec2 startPoint;
+class SlopStartDrag : SlopState {
+private:
     float repeatTimer;
     float multiplier;
-    virtual void setCursorAndPoints( SlopMemory& memory );
+    virtual void setAngleCursor();
 public:
     SlopStartDrag( glm::vec2 point );
     virtual void onEnter( SlopMemory& memory );
     virtual void update( SlopMemory& memory, double dt );
-    virtual void draw( SlopMemory& memory, glm::mat4 matrix );
 };
 
 class SlopEndDrag : SlopState {
@@ -71,26 +78,13 @@ public:
 
 class SlopStartMove : SlopState {
 private:
-    glm::vec2 startPoint;
     glm::vec2 diagonal;
-    virtual void setCursorAndPoints( SlopMemory& memory );
 public:
     SlopStartMove( glm::vec2 oldPoint, glm::vec2 newPoint );
     virtual void onEnter( SlopMemory& memory );
-    virtual void update( SlopMemory& memory, double dt );  
-    virtual void draw( SlopMemory& memory, glm::mat4 matrix );
+    virtual void update( SlopMemory& memory, double dt );
 };
 
-class SlopEndMove : SlopState {
-
-};
-/*
-class SlopResumeDrag : SlopStartDrag {
-public:
-    SlopResumeDrag( glm::vec2 startPoint );
-    virtual void onEnter( SlopMemory& memory );
-};
-*/
 class SlopMemory {
 private:
     SlopState* state;

--- a/src/slopstates.hpp
+++ b/src/slopstates.hpp
@@ -21,8 +21,6 @@
 #ifndef N_SLOPSTATES_H_
 #define N_SLOPSTATES_H_
 
-#include <array>
-
 #include "mouse.hpp"
 #include "keyboard.hpp"
 #include "slop.hpp"

--- a/src/slopstates.hpp
+++ b/src/slopstates.hpp
@@ -41,7 +41,7 @@ public:
     virtual void draw( SlopMemory& memory, glm::mat4 matrix );
 };
 
-class SlopStart : SlopState {
+class SlopStart : protected SlopState {
 private:
     bool setStartPos;
     glm::vec2 startPos;
@@ -51,11 +51,12 @@ public:
     virtual void draw( SlopMemory& memory, glm::mat4 matrix );
 };
 
-class SlopStartDrag : SlopState {
-private:
+class SlopStartDrag : protected SlopState {
+protected:
     glm::vec2 startPoint;
     float repeatTimer;
     float multiplier;
+    virtual void setCursorAndPoints( SlopMemory& memory );
 public:
     SlopStartDrag( glm::vec2 point );
     virtual void onEnter( SlopMemory& memory );
@@ -68,6 +69,28 @@ public:
     virtual void onEnter( SlopMemory& memory );
 };
 
+class SlopStartMove : SlopState {
+private:
+    glm::vec2 startPoint;
+    glm::vec2 diagonal;
+    virtual void setCursorAndPoints( SlopMemory& memory );
+public:
+    SlopStartMove( glm::vec2 oldPoint, glm::vec2 newPoint );
+    virtual void onEnter( SlopMemory& memory );
+    virtual void update( SlopMemory& memory, double dt );  
+    virtual void draw( SlopMemory& memory, glm::mat4 matrix );
+};
+
+class SlopEndMove : SlopState {
+
+};
+/*
+class SlopResumeDrag : SlopStartDrag {
+public:
+    SlopResumeDrag( glm::vec2 startPoint );
+    virtual void onEnter( SlopMemory& memory );
+};
+*/
 class SlopMemory {
 private:
     SlopState* state;


### PR DESCRIPTION
I added the ability to move the selection by holding down the space bar, as suggested in https://github.com/naelstrof/slop/issues/12#issuecomment-483077349 [(it also works like this in Mac OS)](https://twitter.com/sulco/status/1202218689669599234)
There might be mistakes (I don't program often), but it builds and works fine for me :slightly_smiling_face:.

I also restructured slopstates.{cpp,hpp} because I was having difficulty understanding it. I'm still not sure about the compensation when the mouse is on the outermost pixels, so please look over `slop::SlopState::determineCompensation()` carefully.

This should probably solve #12 