### PR TITLE
Add support for nodrag

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,6 +96,9 @@ SlopOptions* getOptions( cxxopts::Options& options ) {
     if ( options.count( "highlight" ) > 0 ) {
         foo->highlight = options["highlight"].as<bool>();
     }
+    if ( options.count( "nodrag" ) > 0 ) {
+        foo->nodrag = options["nodrag"].as<bool>();
+    }
     if ( options.count( "quiet" ) > 0 ) {
         foo->quiet = options["quiet"].as<bool>();
     }
@@ -170,6 +173,8 @@ void printHelp() {
     std::cout << "                                  Alternatively setting it to 999999 would.\n";
     std::cout << "                                  only allow for window selections.\n";
     std::cout << "                                  (default=`2')\n";
+    std::cout << "  -D, --nodrag                  Select region with two clicks instead of\n";
+    std::cout << "                                  click and drag\n";
     std::cout << "  -c, --color=FLOAT,FLOAT,FLOAT,FLOAT\n";
     std::cout << "                                Set the selection rectangle's color. Supports\n";
     std::cout << "                                  RGB or RGBA values.\n";
@@ -232,6 +237,7 @@ int app( int argc, char** argv ) {
     ("b,bordersize", "Sets the selection rectangle's thickness.", cxxopts::value<float>())
     ("p,padding", "Sets the padding size for the selection, this can be negative.", cxxopts::value<float>())
     ("t,tolerance", "How far in pixels the mouse can move after clicking, and still be detected as a normal click instead of a click-and-drag. Setting this to 0 will disable window selections. Alternatively setting it to 9999999 would force a window selection.", cxxopts::value<float>())
+    ("D,nodrag", "Select region with two clicks instead of click and drag")
     ("c,color", "Sets  the  selection  rectangle's  color.  Supports  RGB or RGBA input. Depending on the system's window manager/OpenGL  support, the opacity may be ignored.", cxxopts::value<std::string>())
     ("r,shader", "This  sets  the  vertex shader, and fragment shader combo to use when drawing the final framebuffer to the screen. This obviously only  works  when OpenGL is enabled. The shaders are loaded from ~/.config/maim. See https://github.com/naelstrof/slop for more information on how to create your own shaders.", cxxopts::value<std::string>())
     ("n,nodecorations", "Sets the level of aggressiveness when trying to remove window decorations. `0' is off, `1' will try lightly to remove decorations, and `2' will recursively descend into the root tree until it gets the deepest available visible child under the mouse. Defaults to `0'.", cxxopts::value<int>()->implicit_value("1"))

--- a/src/slop.cpp
+++ b/src/slop.cpp
@@ -70,6 +70,7 @@ slop::SlopOptions::SlopOptions() {
     border = 1;
     nokeyboard = false;
     noopengl = false;
+    nodrag = false;
     nodecorations = false;
     tolerance = 2;
     padding = 0;

--- a/src/slop.hpp
+++ b/src/slop.hpp
@@ -63,6 +63,7 @@ public:
     float border;
     float padding;
     float tolerance;
+    bool nodrag;
     bool highlight;
     bool noopengl;
     bool nokeyboard;

--- a/src/slopstates.cpp
+++ b/src/slopstates.cpp
@@ -7,6 +7,7 @@ slop::SlopMemory::SlopMemory( SlopOptions* options, Rectangle* rect ) {
     state = (SlopState*)new SlopStart();
     nextState = NULL;
     tolerance = options->tolerance;
+    nodrag = options->nodrag;
     nodecorations = options->nodecorations;
     rectangle = rect;
     selectedWindow = x11->root;
@@ -70,7 +71,7 @@ void slop::SlopStart::update( SlopMemory& memory, double dt ) {
         glm::vec4 rect = getWindowGeometry( mouse->hoverWindow, memory.nodecorations );
         memory.rectangle->setPoints( glm::vec2( (float)rect.x, (float)rect.y ), glm::vec2( (float)rect.x+rect.z, (float)rect.y+rect.w ) );
     }
-    if ( setStartPos && !mouse->getButton( 1 ) ) {
+    if ( setStartPos && !mouse->getButton( 1 ) && !memory.nodrag ) {
         memory.selectedWindow = mouse->hoverWindow;
         memory.setState( (SlopState*)new SlopEndDrag() );
     }
@@ -110,7 +111,13 @@ void slop::SlopStartDrag::update( SlopMemory& memory, double dt ) {
                 memory.rectangle->setPoints(startPoint+glm::vec2(1*xm,1*ym), mouse->getMousePos()+glm::vec2(0,0));
                 break;
     }
-    if ( !mouse->getButton( 1 ) ) {
+    if ( memory.nodrag && !up && !mouse->getButton( 1 ) ) {
+        up = true;
+    }
+    if ( memory.nodrag && up && mouse->getButton( 1 ) ) {
+        memory.setState( (SlopState*)new SlopEndDrag() );
+    }
+    if ( !memory.nodrag && !mouse->getButton( 1 ) ) {
         memory.setState( (SlopState*)new SlopEndDrag() );
     }
     if ( keyboard ) {

--- a/src/slopstates.hpp
+++ b/src/slopstates.hpp
@@ -56,6 +56,7 @@ private:
     glm::vec2 startPoint;
     float repeatTimer;
     float multiplier;
+    bool up;
 public:
     SlopStartDrag( glm::vec2 point );
     virtual void onEnter( SlopMemory& memory );
@@ -79,6 +80,7 @@ public:
     bool running;
     float tolerance;
     bool nodecorations;
+    bool nodrag;
     Rectangle* rectangle;
     void setState( SlopState* state );
     void update( double dt );


### PR DESCRIPTION
If the nodrag command line option is passed, allow the user to let go of mouse button 1 while making a selection, and confirm the selection after pressing it again. solves #128 