### PR TITLE
Fix linking of GLEW library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,14 +87,14 @@ target_link_libraries(${LIBRARY_NAME} ${X11_LIBRARIES}
 
 if ( SLOP_OPENGL )
   include_directories( ${XEXT_INCLUDE_DIR}
-                       ${GLEW_INCLUDE_DIR}
+                       GLEW::GLEW
                        ${XRENDER_INCLUDE_DIR}
                        ${OPENGL_INCLUDE_DIR} )
   target_link_libraries(${LIBRARY_NAME} ${OPENGL_LIBRARIES}
                                         ${XRENDER_LIBRARY}
                                         ${CMAKE_THREAD_LIBS_INIT} 
                                         ${GLX_LIBRARY}
-                                        ${GLEW_LIBRARIES})
+                                        GLEW::GLEW)
 endif()
 
 target_link_libraries(${EXECUTABLE_NAME} ${LIBRARY_NAME} )


### PR DESCRIPTION
FindGLEW.cmake Module silently tries to include glew-config.cmake.
If it succeeds, then it stop and return to the caller.
However, glew-config.cmake only sets GLEW::GLEW, resulting in
missing glew shared library at link time.

I've also fixed the inclusion of its header but I am not 100% sure it is correct (cmake docs don't talk about imported target in `include_directories`).

Credits to Eduardo Suarez-Santana for discovering the build error and providing the fix.
https://gitlab.exherbo.org/DanySpin97/danyspin97-exheres/-/issues/2