### PR TITLE
transparency issue fix

### DIFF
--- a/src/slop.cpp
+++ b/src/slop.cpp
@@ -295,12 +295,14 @@ slop::SlopSelection slop::GLSlopSelect( slop::SlopOptions* options, SlopWindow* 
             window->framebuffer->draw(slop::mouse->getMousePos(), elapsed.count()/1000.f, glm::vec4( options->r, options->g, options->b, options->a ) );
             pingpong->unbind();
         }
-        glDisable( GL_BLEND );
+        glClearColor (0.0, 0.0, 0.0, 0.0);
+        glClear (GL_COLOR_BUFFER_BIT);
         if ( i%2 != 0 ) {
             window->framebuffer->draw(slop::mouse->getMousePos(), elapsed.count()/1000.f, glm::vec4( options->r, options->g, options->b, options->a ) );
         } else {
             pingpong->draw(slop::mouse->getMousePos(), elapsed.count()/1000.f, glm::vec4( options->r, options->g, options->b, options->a ) );
         }
+        glDisable( GL_BLEND );
 
         window->display();
         // Here we sleep just to prevent our CPU usage from going to 100%.


### PR DESCRIPTION
There was an issue with the transparency and I saw the last draw from a `Framebuffer` was not in the `GL_BLEND` section.
So I extended it down and added the `glClearColor` and `glClear` calls to match the ones done above.

I honestly don't know what I am doing here so a review from @naelstrof is needed.

This pull request is a follow up on #138