### PR TITLE
Unbreak build with libglvnd >= 1.3.4

### DIFF
--- a/src/x.hpp
+++ b/src/x.hpp
@@ -23,6 +23,7 @@
 
 #include <iostream>
 #include <X11/Xlib.h>
+#include <X11/Xutil.h>
 #include <string>
 #include <sstream>
 #include <stdexcept>


### PR DESCRIPTION
Regressed by https://github.com/KhronosGroup/EGL-Registry/commit/64aa561f1971. See [error log](http://www.ipv6proxy.net/go.php?u=http://package18.nyi.freebsd.org/data/122amd64-default-foo/2021-09-08_15h09m16s/logs/errors/slop-7.5_5.log). Curiously, GCC suggests `eglDestroyImage` while Clang suggests `XDestroyIC` as replacements in their error messages.