### PR TITLE
bugfix: add missed header

### DIFF
--- a/src/framebuffer.cpp
+++ b/src/framebuffer.cpp
@@ -1,3 +1,4 @@
+#include <X11/Xutil.h>
 #include "framebuffer.hpp"
 
 slop::Framebuffer::Framebuffer( int w, int h ) {


### PR DESCRIPTION
XDestroyImage is included in <X11/Xutil.h> which belongs to libX11.
Build fails without include this header on Gentoo.

Signed-off-by: Drunkard Zhang <gongfan193@gmail.com>