### PR TITLE
Improve man page for better apropos results

### DIFF
--- a/slop.1
+++ b/slop.1
@@ -1,8 +1,8 @@
 .\" Manpage for slop.
 .\" Contact naelstrof@gmail.com to correct errors or typos.
-.TH SLOP 1 2017-03-21 Linux "slop man page"
+.TH SLOP 1 2021-02-03 Linux "slop man page"
 .SH NAME
-slop \- select operation
+slop \- select operation, either mark screen region or pick window
 .SH SYNOPSIS
 slop [-klqn] [OPTIONS]
 .SH DESCRIPTION


### PR DESCRIPTION
The man page could be improved to have better apropos(1) results. IOW,
to make the program appear with search terms that come to mind first,
as "select operation" is true but too abstract. See attached patch.

Background: managed to find forgotten maim(1) via slop, but realized
both have rather short name blocks, making them rather invisible to
apropos unless you get the right word (of two possible). man -K uses
full man page text (slow, also in the sense of having to hit C-d many
times), while man -k or apropos seem to only use the one line name
part.

This is a forward of a Debian bug report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=981703