### PR TITLE
Arguments to change move and adjust keybindings

### DIFF
--- a/src/keyboard.hpp
+++ b/src/keyboard.hpp
@@ -23,8 +23,10 @@
 
 #define XK_MISCELLANY
 #define XK_LATIN1 // for XK_space
-#include <X11/keysymdef.h>
+#define XK_MISCELLANY // for modifier KeySyms
 
+#include <vector>
+#include <X11/keysymdef.h>
 #include "x.hpp"
 
 namespace slop {
@@ -34,8 +36,15 @@ private:
     char deltaState[32];
     X11* x11;
     bool keyDown;
+
+    // KeySym to move the selection window
+    KeySym keyMove;
+
+    // KeySyms to adjust selection window
+    //  in the order of Left Down Up Right
+    std::vector<KeySym> keyAdjust;
 public:
-    Keyboard( X11* x11 );
+    Keyboard( X11* x11 , KeySym keyMove, std::vector<KeySym> keyAdjust);
     ~Keyboard();
     void update();
     bool getKey( KeySym key );

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,60 @@
 #include "slop.hpp"
 #include "cxxopts.hpp"
 
+#include <X11/keysymdef.h>
+#include "x.hpp"
+
 using namespace slop;
+
+std::vector<KeySym> parseAdjustKeys( std::string value ) {
+    std::string valuecopy = value;
+    std::vector<KeySym> found;
+    std::string delimiter = ",";
+    std::string::size_type sz;
+    std::string keysymString;
+    char* keysymChars;
+    KeySym keysym;
+    bool validity = true;
+    try {
+        sz = value.find(delimiter);
+        keysymString = value.substr(0, sz);
+        keysymChars = &keysymString[0];
+        keysym = XStringToKeysym(keysymChars);
+        found.push_back(keysym);
+        value = value.substr(sz + delimiter.size());
+        validity = validity && keysym;
+
+        sz = value.find(delimiter);
+        keysymString = value.substr(0, sz);
+        keysymChars = &keysymString[0];
+        keysym = XStringToKeysym(keysymChars);
+        found.push_back(keysym);
+        value = value.substr(sz + delimiter.size());
+        validity = validity && keysym;
+
+        sz = value.find(delimiter);
+        keysymString = value.substr(0, sz);
+        keysymChars = &keysymString[0];
+        keysym = XStringToKeysym(keysymChars);
+        found.push_back(keysym);
+        value = value.substr(sz + delimiter.size());
+        validity = validity && keysym;
+
+        keysymString = value;
+        keysymChars = &keysymString[0];
+        keysym = XStringToKeysym(keysymChars);
+        found.push_back(keysym);
+        validity = validity && keysym;
+
+        if ( !validity ) throw std::runtime_error("dur");
+    } catch ( ... ) {
+        throw std::invalid_argument("Unable to parse value `" 
+                + valuecopy 
+                + "` as a series of keysyms. Should be something like Left,Down,Up,Right");
+    }
+
+    return found;
+}
 
 glm::vec4 parseColor( std::string value ) {
     std::string valuecopy = value;
@@ -108,6 +161,20 @@ SlopOptions* getOptions( cxxopts::Options& options ) {
             throw std::invalid_argument( "--nodecorations must be between 0 and 2. Or be used as a flag." );
         }
     }
+    if ( options.count( "movekey" ) > 0 ) {
+        const char* keyMove = &options["movekey"].as<std::string>()[0];
+        KeySym keysym = XStringToKeysym(keyMove);
+        foo->keyMove = keysym;
+        if ( keysym == 0 )
+            throw std::invalid_argument("Unable to parse value `" 
+                    + options["movekey"].as<std::string>()
+                    + "` as a keysym.");
+    }
+    std::vector<KeySym> keyAdjust { XK_Up, XK_Down, XK_Up, XK_Right };
+    if ( options.count( "adjustkey" ) > 0 ) {
+        keyAdjust = parseAdjustKeys( options["adjustkey"].as<std::string>() );
+    }
+    foo->keyAdjust = keyAdjust;
     return foo;
 }
 
@@ -246,6 +313,8 @@ int app( int argc, char** argv ) {
     ("q,quiet", "Disable any unnecessary cerr output. Any warnings or info simply won't print.")
     ("k,nokeyboard", "Disables the ability to cancel selections with the keyboard.")
     ("o,noopengl", "Disables graphics hardware acceleration.")
+    ("m,movekey", "Set move key, hold move key while selecting to move selection box", cxxopts::value<std::string>())
+    ("a,adjustkey", "Set adjustment key, moves the corner opposite to the mouse corner", cxxopts::value<std::string>())
     ("positional", "Positional parameters", cxxopts::value<std::vector<std::string>>())
     ;
     options.parse_positional("positional");

--- a/src/slop.cpp
+++ b/src/slop.cpp
@@ -111,7 +111,7 @@ slop::SlopSelection slop::SlopSelect( slop::SlopOptions* options ) {
     x11 = new X11(options->xdisplay);
     if ( !options->nokeyboard ) {
         XErrorHandler ph = XSetErrorHandler(slop::TmpXError);
-        keyboard = new Keyboard( x11 );
+        keyboard = new Keyboard( x11, options->keyMove, options->keyAdjust );
         XSetErrorHandler(ph);
     }
 #ifdef SLOP_OPENGL

--- a/src/slop.hpp
+++ b/src/slop.hpp
@@ -20,6 +20,9 @@
 
 #ifndef N_SLOP_H_
 #define N_SLOP_H_
+#include <X11/keysymdef.h>
+#include "x.hpp"
+#include <vector>
 
 // Here we make some C-styled structs and function definitions, 
 // allows other people to have a pure C interface to slop.
@@ -74,6 +77,8 @@ public:
     float b;
     float a;
     char* xdisplay;
+    KeySym keyMove;
+    std::vector<KeySym> keyAdjust;
 };
 
 class SlopSelection {

--- a/src/slopstates.cpp
+++ b/src/slopstates.cpp
@@ -3,6 +3,8 @@
 using namespace slop;
 
 slop::SlopMemory::SlopMemory( SlopOptions* options, Rectangle* rect ) {
+    this->keyMove = options->keyMove;
+    this->keyAdjust = options->keyAdjust;
     up = false;
     running = true;
     state = (SlopState*)new SlopStart();
@@ -128,13 +130,13 @@ void slop::SlopStartDrag::update( SlopMemory& memory, double dt ) {
     }
 
     if ( keyboard ) {
-        if ( keyboard->getKey(XK_space) ) {
+        if ( keyboard->getKey(memory.keyMove) ) {
             memory.setState( (SlopState*)new SlopStartMove( startPoint, mouse->getMousePos() ) );
             return;
         }
         int arrows[2];
-        arrows[0] = keyboard->getKey(XK_Down)-keyboard->getKey(XK_Up);
-        arrows[1] = keyboard->getKey(XK_Right)-keyboard->getKey(XK_Left);
+        arrows[0] = keyboard->getKey(memory.keyAdjust[1])-keyboard->getKey(memory.keyAdjust[2]);
+        arrows[1] = keyboard->getKey(memory.keyAdjust[3])-keyboard->getKey(memory.keyAdjust[0]);
         if ( arrows[0] || arrows[1] ) {
             if ( repeatTimer == 0 || repeatTimer > .4 ) {
                 startPoint.y += arrows[0]*multiplier;
@@ -179,7 +181,7 @@ void slop::SlopStartMove::update( SlopMemory& memory, double dt ) {
 
     // space or mouse1 released, return to drag
     // if mouse1 is released then drag will end also
-    if ( !keyboard->getKey(XK_space) or (!mouse->getButton( 1 ) && !memory.nodrag) ) {
+    if ( !keyboard->getKey(memory.keyMove) or (!mouse->getButton( 1 ) && !memory.nodrag) ) {
         // clip rectangle on edges of screen.
         startPoint.x = glm::min((int)startPoint.x, WidthOfScreen(x11->screen));
         startPoint.x = glm::max((int)startPoint.x, 0);

--- a/src/slopstates.hpp
+++ b/src/slopstates.hpp
@@ -27,6 +27,10 @@
 
 #include "rectangle.hpp"
 
+#include <vector>
+#include <X11/keysymdef.h>
+#include "x.hpp"
+
 namespace slop {
 
 class SlopMemory;
@@ -57,7 +61,7 @@ private:
     float repeatTimer;
     float multiplier;
 public:
-    SlopStartDrag( glm::vec2 point );
+    SlopStartDrag( glm::vec2 point);
     virtual void onEnter( SlopMemory& memory );
     virtual void update( SlopMemory& memory, double dt );
 };
@@ -90,6 +94,8 @@ public:
     bool nodrag;
     bool up;
     Rectangle* rectangle;
+    KeySym keyMove;
+    std::vector<KeySym> keyAdjust;
     void setState( SlopState* state );
     void update( double dt );
     void draw( glm::mat4& matrix );


### PR DESCRIPTION
Added flag `-m` and `-a` to allow using KeySym to change the keybindings for move selection and adjust selection.