### PR TITLE
Add EPEL (RHEL and CentOS Stream) to distro list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ While slop not only looks nicer, it's impossible for it to end up in screenshots
 * [Debian: slop](https://packages.debian.org/sid/slop)
 * [Ubuntu: slop](https://packages.ubuntu.com/slop)
 * [Fedora: slop](https://src.fedoraproject.org/rpms/slop)
+* [Red Hat Enterprise Linux (via EPEL): slop](https://src.fedoraproject.org/rpms/slop)
+* [CentOS Stream and similar (via EPEL): slop](https://src.fedoraproject.org/rpms/slop)
 * [Ravenports: slop](http://www.ravenports.com/catalog/bucket_CB/slop/standard/)
 * [Alpine Linux: testing/slop](https://pkgs.alpinelinux.org/package/edge/testing/x86_64/slop)
 * Please make a package for slop on your favorite system, and make a pull request to add it to this list.


### PR DESCRIPTION
slop [has been added][1] to [EPEL][2] (Extra Packages for Enterprise Linux), meaning it can be installed on RHEL (8 and 9) and compatible RHEL based distributions such as and CentOS Stream.

EPEL is maintained as part of Fedora, so same link applies.

 [1]: https://bugzilla.redhat.com/show_bug.cgi?id=2196635
 [2]: https://docs.fedoraproject.org/en-US/epel/