### PR TITLE
add outputs for width and height rounded to even numbers

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -135,6 +135,8 @@ std::string formatOutput( std::string input, SlopSelection selection ) {
                 case 'i':
                 case 'I': output << selection.id; break;
                 case '%': output << "%"; break;
+                case 'm': output << round(selection.w / 2.0) * 2; break;
+                case 'n': output << round(selection.h / 2.0) * 2; break;
                 default: throw std::invalid_argument( std::string()+"Expected x, y, w, h, g, i, c, or % after % in format. Got `" + input[i+1] + "`." );
              }
             i++;


### PR DESCRIPTION
having even number outputs is nice because then you can use `-pix_fmt yuv420p` with ffmpeg when recording the screen. This results in smaller file sizes and better hardware support.

```
#!/bin/bash
geometry=$(slop -f "-video_size %mx%n -i $DISPLAY.0+%x,%y")
ffmpeg -y -framerate 60 -f x11grab $geometry -pix_fmt yuv420p "$1"
```

Otherwise, ffmpeg will complain:

```
[libx264 @ 0x562cfa9437c0] height not divisible by 2 (52x125)
Error initializing output stream 0:0 -- Error while opening encoder for output stream #0:0 - maybe incorrect parameters such as bit_rate, rate, width or height
```