### PR TITLE
High refresh monitor support part 2

### DIFF
--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -61,7 +61,7 @@ slop::Keyboard::Keyboard( X11* x11 ) {
     int err = XGrabKeyboard( x11->display, x11->root, False, GrabModeAsync, GrabModeAsync, CurrentTime );
     int tries = 0;
     while( err != GrabSuccess && tries < 5 ) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         err = XGrabKeyboard( x11->display, x11->root, False, GrabModeAsync, GrabModeAsync, CurrentTime );
         tries++;
     }

--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -51,7 +51,7 @@ slop::Mouse::Mouse(X11* x11, int nodecorations, Window ignoreWindow ) {
                             GrabModeAsync, GrabModeAsync, None, xcursor, CurrentTime );
     int tries = 0;
     while( err != GrabSuccess && tries < 5 ) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         err = XGrabPointer( x11->display, x11->root, True,
                                 PointerMotionMask | ButtonPressMask | ButtonReleaseMask | EnterWindowMask,
                                 GrabModeAsync, GrabModeAsync, None, xcursor, CurrentTime );

--- a/src/slop.cpp
+++ b/src/slop.cpp
@@ -213,7 +213,6 @@ slop::SlopSelection slop::XShapeSlopSelect( slop::SlopOptions* options ) {
         XEvent event;
         if ( XCheckTypedEvent( x11->display, UnmapNotify, &event ) ) { break; }
         if ( XCheckTypedEvent( x11->display, DestroyNotify, &event ) ) { break; }
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
         tries++;
     }
     // Finally return the data.
@@ -333,7 +332,6 @@ slop::SlopSelection slop::GLSlopSelect( slop::SlopOptions* options, SlopWindow* 
         XEvent event;
         if ( XCheckTypedEvent( x11->display, UnmapNotify, &event ) ) { break; }
         if ( XCheckTypedEvent( x11->display, DestroyNotify, &event ) ) { break; }
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
         tries++;
     }
     // Finally return the data.

--- a/src/slop.cpp
+++ b/src/slop.cpp
@@ -290,7 +290,7 @@ slop::SlopSelection slop::GLSlopSelect( slop::SlopOptions* options, SlopWindow* 
 
         window->display();
         // Here we sleep just to prevent our CPU usage from going to 100%.
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         GLenum err = glGetError();
         if ( err != GL_NO_ERROR ) {
             std::string error;

--- a/src/slop.cpp
+++ b/src/slop.cpp
@@ -289,8 +289,6 @@ slop::SlopSelection slop::GLSlopSelect( slop::SlopOptions* options, SlopWindow* 
         glDisable( GL_BLEND );
 
         window->display();
-        // Here we sleep just to prevent our CPU usage from going to 100%.
-        std::this_thread::sleep_for(std::chrono::milliseconds(1));
         GLenum err = glGetError();
         if ( err != GL_NO_ERROR ) {
             std::string error;


### PR DESCRIPTION
While my previous fix to issue #168 worked, it only did so for the XShape version of slop.
This change fixes it for the OpenGL version. 

Using a 10 millisecond sleep between each update caused the issue because it means each frame takes at minimum 10 milliseconds to generate. Frametimes for any monitor with a refresh rate greater than 100 are less than ten milliseconds. This limits the frame rate to 100. This line is unnecessary because window->display(); called in the previous line calls glXSwapBuffers, which pauses program execution until the monitor is ready for the next frame. This serves the same use as sleep_for() while conforming to monitor refresh rate. 

Note: glXSwapBuffers only has this pausing behavior when v sync is enabled. I, However, tested the program with v sync disabled in my compositor settings and still noticed no spike in CPU usage, so I don't think this line is necessary either way. If needed though, changing the delay to 1 millisecond would also fix the issue.